### PR TITLE
ci: set workflow token permissions

### DIFF
--- a/.github/workflows/kubeapps-main.yaml
+++ b/.github/workflows/kubeapps-main.yaml
@@ -20,5 +20,8 @@ concurrency:
 
 jobs:
   CI:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/kubeapps-general.yaml
     secrets: inherit

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,6 +28,9 @@ on:
         default: "v2.6.2"
         description: "golangci-lint version to use"
 
+permissions:
+  contents: read
+
 jobs:
   yaml-linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set explicit token permissions for the main CI workflow call
- make linter workflow jobs read-only

Fixes #54

## Checks
- yaml-lint .github/workflows/kubeapps-main.yaml .github/workflows/linters.yml
- git diff --check
