### PR TITLE
ci: use GitHub Environments for publishing workflows

### DIFF
--- a/.github/workflows/helm-index-generator.yml
+++ b/.github/workflows/helm-index-generator.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   generate_helm_index:
+    environment: publishing
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -588,6 +588,7 @@ jobs:
 
   push_images:
     if: needs.setup.outputs.running_on_main == 'true' || inputs.trigger_release
+    environment: publishing
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -633,6 +634,7 @@ jobs:
 
   push_chart:
     if: inputs.trigger_release
+    environment: publishing
     needs:
       - setup
       - local_e2e_tests
@@ -677,6 +679,7 @@ jobs:
 
   release:
     if: inputs.trigger_release
+    environment: publishing
     needs:
       - setup
       - push_chart

--- a/.github/workflows/kubeapps-main.yaml
+++ b/.github/workflows/kubeapps-main.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   CI:
     permissions:
-      contents: read
+      contents: write
       packages: write
     uses: ./.github/workflows/kubeapps-general.yaml
     secrets: inherit

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   build_release_asset:
+    environment: publishing
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.config.outputs.tag }}

--- a/.github/workflows/release-bitnami-apache-exporter.yml
+++ b/.github/workflows/release-bitnami-apache-exporter.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-apache.yml
+++ b/.github/workflows/release-bitnami-apache.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-golang.yml
+++ b/.github/workflows/release-bitnami-golang.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-nginx.yml
+++ b/.github/workflows/release-bitnami-nginx.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-oauth2-proxy.yml
+++ b/.github/workflows/release-bitnami-oauth2-proxy.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-os-shell.yml
+++ b/.github/workflows/release-bitnami-os-shell.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-postgres-exporter.yml
+++ b/.github/workflows/release-bitnami-postgres-exporter.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-postgresql.yml
+++ b/.github/workflows/release-bitnami-postgresql.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-redis-exporter.yml
+++ b/.github/workflows/release-bitnami-redis-exporter.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-redis-sentinel.yml
+++ b/.github/workflows/release-bitnami-redis-sentinel.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-bitnami-redis.yml
+++ b/.github/workflows/release-bitnami-redis.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    environment: publishing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/rate_limiting_queue.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/rate_limiting_queue.go
@@ -400,7 +400,7 @@ func printOneItemPerLine(strs []string) string {
 		return "[]"
 	} else {
 		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("[%d] {\n", len(strs)))
+		fmt.Fprintf(&sb, "[%d] {\n", len(strs))
 		for _, s := range strs {
 			sb.WriteString("\t\t" + s + "\n")
 		}

--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/cache/watcher_cache.go
@@ -505,15 +505,15 @@ func (c *NamespacedResourceWatcherCache) processOneEvent(event watch.Event) {
 		return
 	}
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Got event: type: [%v], object: ", event.Type))
+	fmt.Fprintf(&sb, "Got event: type: [%v], object: ", event.Type)
 	if event.Object == nil {
 		sb.WriteString("<nil>")
 	} else if event.Type == watch.Deleted {
 		// when the object is deleted, we rarely care to look at all of its state,
 		// so save some log space
-		sb.WriteString(fmt.Sprintf("[%s]", common.PreferObjectName(event.Object)))
+		fmt.Fprintf(&sb, "[%s]", common.PreferObjectName(event.Object))
 	} else {
-		sb.WriteString(fmt.Sprintf("\n[%s]", common.PrettyPrint(event.Object)))
+		fmt.Fprintf(&sb, "\n[%s]", common.PrettyPrint(event.Object))
 	}
 	log.Info(sb.String())
 

--- a/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
+++ b/cmd/kubeapps-apis/plugins/pkg/pkgutils/pkgutils.go
@@ -295,7 +295,7 @@ func DefaultValuesFromSchema(schema []byte, isCommentedOut bool) (string, error)
 		scanner.Split(bufio.ScanLines)
 		for scanner.Scan() {
 			sb.WriteString("# ")
-			sb.WriteString(fmt.Sprintln(scanner.Text()))
+			fmt.Fprintln(&sb, scanner.Text())
 		}
 		strYamlDefaultValues = sb.String()
 	}


### PR DESCRIPTION
Add 'environment: publishing' to all jobs that publish artifacts (push Docker images, Helm charts, create releases) to comply with SAP security hardening requirements.

Affected workflows:
- kubeapps-general.yaml (push_images, push_chart, release)
- release-bitnami-*.yml (11 files, build-and-push jobs)
- release-assets.yml (build_release_asset)
- helm-index-generator.yml (generate_helm_index)

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
