### PR TITLE
fix/42 oci chart devel image tags

### DIFF
--- a/.github/workflows/kubeapps-general.yaml
+++ b/.github/workflows/kubeapps-general.yaml
@@ -639,8 +639,6 @@ jobs:
       - setup
       - local_e2e_tests
     runs-on: ubuntu-latest
-    env:
-      CHART_DIR: chart/kubeapps
     steps:
       - uses: actions/checkout@v5
       - name: Install Helm
@@ -648,34 +646,30 @@ jobs:
           set -eu
           source ./script/lib/libcitools.sh
           installHelm ${HELM_VERSION_STABLE} helm-stable
-      - name: Show chart version
-        run: |
-          set -eu
-          grep '^version:' ${CHART_DIR}/Chart.yaml || true
       - name: Login to GHCR (OCI) for Helm
         run: |
           set -eu
           helm registry login ghcr.io --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}"
-      - name: Update chart dependencies
+      - name: Build release asset (with version/tag substitutions)
+        id: build
         run: |
           set -eu
-          helm dependency update ${CHART_DIR}
-      - name: Package chart
-        run: |
-          set -eu
-          helm package ${CHART_DIR} --destination /tmp
-          ls -l /tmp | grep kubeapps- || true
+          echo "Building release asset for tag: ${GITHUB_REF_NAME}"
+          ASSET_PATH=$(bash script/prepare_release_asset.sh "${GITHUB_REF_NAME}")
+          echo "asset_path=${ASSET_PATH}" >> "$GITHUB_OUTPUT"
+          echo "Asset created: ${ASSET_PATH}"
+          ls -lh "${ASSET_PATH}"
       - name: Push chart to GHCR
         run: |
           set -eu
-          CHART_PACKAGE=$(ls /tmp/kubeapps-*.tgz)
+          CHART_PACKAGE="${{ steps.build.outputs.asset_path }}"
           echo "Pushing ${CHART_PACKAGE} to oci://${CHART_OCI_REPO}"
           helm push "${CHART_PACKAGE}" oci://${CHART_OCI_REPO}
       - name: Upload chart artifact
         uses: actions/upload-artifact@v4
         with:
           name: kubeapps-chart
-          path: /tmp/kubeapps-*.tgz
+          path: ${{ steps.build.outputs.asset_path }}
 
   release:
     if: inputs.trigger_release


### PR DESCRIPTION
### Description of the change

The `push_chart` CI job in `.github/workflows/kubeapps-general.yaml` was packaging the raw source
`chart/kubeapps/` directly with `helm package` and pushing it to the OCI registry at
`ghcr.io/sap/kubeapps/kubeapps`. Because the source files intentionally contain the development
placeholders `version: 0.0.0-dev` (in `Chart.yaml`) and `tag: DEVEL` (in `values.yaml`), the
published OCI chart always had these placeholder values regardless of the release tag.

This PR replaces the `Update chart dependencies` + `Package chart` steps in `push_chart` with a
call to `script/prepare_release_asset.sh`, which:

1. Copies the chart to a temporary directory
2. Substitutes `version: 0.0.0-dev` → real release version in `Chart.yaml`
3. Substitutes all `tag: DEVEL` → real release tag for every component image in `values.yaml`
4. Runs `helm package` on the modified copy and returns the path to the resulting `.tgz`

The output `.tgz` is then pushed to GHCR via `helm push` — the same correctly-substituted
artifact that the `release-assets` workflow already uses to produce the GitHub Release `.tgz`.

### Benefits

- `helm install kubeapps oci://ghcr.io/sap/kubeapps/kubeapps` now works correctly for any
  release tag, with the right chart version and real image tags in `values.yaml`.
- The OCI chart and the GitHub Release `.tgz` are now built from the same source, ensuring
  consistency between the two distribution methods.
- No duplication of substitution logic — reuses the existing, already-tested
  `script/prepare_release_asset.sh`.

### Possible drawbacks

None. The change is limited to the CI pipeline and does not affect the source chart files,
application code, or the GitHub Release `.tgz` asset (which was already correct).

### Applicable issues

- fixes #<issue-number>

### Additional information

The `release` job (which calls `script/create_release.sh` → `script/prepare_release_asset.sh`)
is unaffected and continues to produce the correct GitHub Release `.tgz` as before.

**Files changed:**
- `.github/workflows/kubeapps-general.yaml` — `push_chart` job only
