### PR TITLE
docs(changelog): add v3.0.1 entry for OCI chart push fix

### DIFF
--- a/chart/kubeapps/CHANGELOG.md
+++ b/chart/kubeapps/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+## v3.0.1 (2026-07-10)
+
+* [bitnami/build] Fix OCI chart push to use correct version and image tags on release ([#61](https://github.com/SAP/kubeapps/pull/61))
+
 ## v3.0.0 (2025-12-23)
 
 The version of the helm chart and application is now aligned on v3.0.0.


### PR DESCRIPTION
### Description of the change

Updates `chart/kubeapps/CHANGELOG.md` to document the `v3.0.1` patch release.

The entry records the bug fix introduced in #61, which corrected the OCI chart push job
(`CI / push_chart`) in `.github/workflows/kubeapps-general.yaml` to call
`script/prepare_release_asset.sh` before packaging and pushing the chart. Without this fix,
the OCI chart was always published with the development placeholders `version: 0.0.0-dev` and
`tag: DEVEL` for all component images, causing `ImagePullBackOff` on every `helm install` from
the OCI registry.

### Benefits

- Keeps the changelog up to date so users and maintainers can track what changed between releases.
- Documents the `v3.0.1` patch version, confirming this is a bug-fix-only release with no new
  features or breaking changes.

### Possible drawbacks

None. This is a documentation-only change.

### Applicable issues

- fixes #60

### Additional information

The `v3.0.1` version follows [Semantic Versioning](https://semver.org/): only the **patch**
component is incremented (`3.0.0` → `3.0.1`) because the change is a bug fix with no new
features or breaking changes.

**Files changed:**
- `chart/kubeapps/CHANGELOG.md` — added `v3.0.1` entry
