### PR TITLE
fix(kubeapps-apis): log the request message, not the connect request

### DIFF
--- a/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/fluxv2/packages/v1alpha1/server.go
@@ -260,7 +260,7 @@ func (s *Server) GetAvailablePackageDetail(ctx context.Context, request *connect
 
 // GetAvailablePackageVersions returns the package versions managed by the 'fluxv2' plugin
 func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *connect.Request[corev1.GetAvailablePackageVersionsRequest]) (*connect.Response[corev1.GetAvailablePackageVersionsResponse], error) {
-	log.Infof("+fluxv2 GetAvailablePackageVersions [%v]", request)
+	log.Infof("+fluxv2 GetAvailablePackageVersions [%v]", request.Msg)
 	defer log.Info("-fluxv2 GetAvailablePackageVersions")
 
 	if request.Msg.GetPkgVersion() != "" {
@@ -302,7 +302,7 @@ func (s *Server) GetAvailablePackageVersions(ctx context.Context, request *conne
 
 // GetInstalledPackageSummaries returns the installed packages managed by the 'fluxv2' plugin
 func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *connect.Request[corev1.GetInstalledPackageSummariesRequest]) (*connect.Response[corev1.GetInstalledPackageSummariesResponse], error) {
-	log.Infof("+fluxv2 GetInstalledPackageSummaries [%v]", request)
+	log.Infof("+fluxv2 GetInstalledPackageSummaries [%v]", request.Msg)
 	itemOffset, err := paginate.ItemOffsetFromPageToken(request.Msg.GetPaginationOptions().GetPageToken())
 	if err != nil {
 		return nil, err
@@ -336,7 +336,7 @@ func (s *Server) GetInstalledPackageSummaries(ctx context.Context, request *conn
 
 // GetInstalledPackageDetail returns the package metadata managed by the 'fluxv2' plugin
 func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *connect.Request[corev1.GetInstalledPackageDetailRequest]) (*connect.Response[corev1.GetInstalledPackageDetailResponse], error) {
-	log.Infof("+fluxv2 GetInstalledPackageDetail [%v]", request)
+	log.Infof("+fluxv2 GetInstalledPackageDetail [%v]", request.Msg)
 
 	if request == nil || request.Msg.InstalledPackageRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request InstalledPackageRef provided"))
@@ -366,7 +366,7 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *connect
 
 // CreateInstalledPackage creates an installed package based on the request.
 func (s *Server) CreateInstalledPackage(ctx context.Context, request *connect.Request[corev1.CreateInstalledPackageRequest]) (*connect.Response[corev1.CreateInstalledPackageResponse], error) {
-	log.Infof("+fluxv2 CreateInstalledPackage [%v]", request)
+	log.Infof("+fluxv2 CreateInstalledPackage [%v]", request.Msg)
 
 	if request == nil || request.Msg.AvailablePackageRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request AvailablePackageRef provided"))
@@ -410,7 +410,7 @@ func (s *Server) CreateInstalledPackage(ctx context.Context, request *connect.Re
 
 // UpdateInstalledPackage updates an installed package based on the request.
 func (s *Server) UpdateInstalledPackage(ctx context.Context, request *connect.Request[corev1.UpdateInstalledPackageRequest]) (*connect.Response[corev1.UpdateInstalledPackageResponse], error) {
-	log.Infof("+fluxv2 UpdateInstalledPackage [%v]", request)
+	log.Infof("+fluxv2 UpdateInstalledPackage [%v]", request.Msg)
 
 	if request == nil || request.Msg.InstalledPackageRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request InstalledPackageRef provided"))
@@ -439,7 +439,7 @@ func (s *Server) UpdateInstalledPackage(ctx context.Context, request *connect.Re
 
 // DeleteInstalledPackage deletes an installed package.
 func (s *Server) DeleteInstalledPackage(ctx context.Context, request *connect.Request[corev1.DeleteInstalledPackageRequest]) (*connect.Response[corev1.DeleteInstalledPackageResponse], error) {
-	log.Infof("+fluxv2 DeleteInstalledPackage [%v]", request)
+	log.Infof("+fluxv2 DeleteInstalledPackage [%v]", request.Msg)
 
 	if request == nil || request.Msg.InstalledPackageRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request InstalledPackageRef provided"))
@@ -519,7 +519,7 @@ func (s *Server) AddPackageRepository(ctx context.Context, request *connect.Requ
 }
 
 func (s *Server) GetPackageRepositoryDetail(ctx context.Context, request *connect.Request[corev1.GetPackageRepositoryDetailRequest]) (*connect.Response[corev1.GetPackageRepositoryDetailResponse], error) {
-	log.Infof("+fluxv2 GetPackageRepositoryDetail [%v]", request)
+	log.Infof("+fluxv2 GetPackageRepositoryDetail [%v]", request.Msg)
 	defer log.Info("-fluxv2 GetPackageRepositoryDetail")
 	if request == nil || request.Msg.PackageRepoRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request AvailablePackageRef provided"))
@@ -548,7 +548,7 @@ func (s *Server) GetPackageRepositoryDetail(ctx context.Context, request *connec
 
 // GetPackageRepositorySummaries returns the package repositories managed by the 'fluxv2' plugin
 func (s *Server) GetPackageRepositorySummaries(ctx context.Context, request *connect.Request[corev1.GetPackageRepositorySummariesRequest]) (*connect.Response[corev1.GetPackageRepositorySummariesResponse], error) {
-	log.Infof("+fluxv2 GetPackageRepositorySummaries [%v]", request)
+	log.Infof("+fluxv2 GetPackageRepositorySummaries [%v]", request.Msg)
 	cluster := request.Msg.GetContext().GetCluster()
 	if cluster != "" && cluster != s.kubeappsCluster {
 		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("not supported yet: request.Context.Cluster: [%v]", cluster))
@@ -565,7 +565,7 @@ func (s *Server) GetPackageRepositorySummaries(ctx context.Context, request *con
 
 // UpdatePackageRepository updates a package repository based on the request.
 func (s *Server) UpdatePackageRepository(ctx context.Context, request *connect.Request[corev1.UpdatePackageRepositoryRequest]) (*connect.Response[corev1.UpdatePackageRepositoryResponse], error) {
-	log.Infof("+fluxv2 UpdatePackageRepository [%v]", request)
+	log.Infof("+fluxv2 UpdatePackageRepository [%v]", request.Msg)
 	if request == nil || request.Msg.PackageRepoRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request PackageRepoRef provided"))
 	}
@@ -587,7 +587,7 @@ func (s *Server) UpdatePackageRepository(ctx context.Context, request *connect.R
 
 // DeletePackageRepository deletes a package repository based on the request.
 func (s *Server) DeletePackageRepository(ctx context.Context, request *connect.Request[corev1.DeletePackageRepositoryRequest]) (*connect.Response[corev1.DeletePackageRepositoryResponse], error) {
-	log.Infof("+fluxv2 DeletePackageRepository [%v]", request)
+	log.Infof("+fluxv2 DeletePackageRepository [%v]", request.Msg)
 	if request == nil || request.Msg.PackageRepoRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request PackageRepoRef provided"))
 	}
@@ -606,7 +606,7 @@ func (s *Server) DeletePackageRepository(ctx context.Context, request *connect.R
 }
 
 func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *connect.Request[corev1.GetPackageRepositoryPermissionsRequest]) (*connect.Response[corev1.GetPackageRepositoryPermissionsResponse], error) {
-	log.Infof("+fluxv2 GetPackageRepositoryPermissions [%v]", request)
+	log.Infof("+fluxv2 GetPackageRepositoryPermissions [%v]", request.Msg)
 
 	cluster := request.Msg.GetContext().GetCluster()
 	namespace := request.Msg.GetContext().GetNamespace()

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/repositories.go
@@ -646,7 +646,7 @@ func (s *Server) deleteRepo(ctx context.Context, headers http.Header, cluster st
 }
 
 func (s *Server) GetPackageRepositoryPermissions(ctx context.Context, request *connect.Request[corev1.GetPackageRepositoryPermissionsRequest]) (*connect.Response[corev1.GetPackageRepositoryPermissionsResponse], error) {
-	log.Infof("+helm GetPackageRepositoryPermissions [%v]", request)
+	log.Infof("+helm GetPackageRepositoryPermissions [%v]", request.Msg)
 
 	cluster := request.Msg.GetContext().GetCluster()
 	namespace := request.Msg.GetContext().GetNamespace()

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -1251,7 +1251,7 @@ func (s *Server) UpdatePackageRepository(ctx context.Context, request *connect.R
 }
 
 func (s *Server) DeletePackageRepository(ctx context.Context, request *connect.Request[corev1.DeletePackageRepositoryRequest]) (*connect.Response[corev1.DeletePackageRepositoryResponse], error) {
-	log.Infof("+helm DeletePackageRepository [%v]", request)
+	log.Infof("+helm DeletePackageRepository [%v]", request.Msg)
 
 	if request == nil || request.Msg.PackageRepoRef == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("no request PackageRepoRef provided"))


### PR DESCRIPTION
## Summary

Thirteen handler entry logs in the `helm` (2) and `fluxv2` (11) plugins of `kubeapps-apis` format the whole `*connect.Request` with `%v`:

```go
log.Infof("+helm GetPackageRepositoryPermissions [%v]", request)
```

`%v` on a `connect.Request` prints the protobuf message **and the HTTP headers**. With the chart's oauth2-proxy defaults (`--pass-authorization-header=true`, `--pass-access-token=true`) that puts the dashboard user's `Authorization: Bearer <id token>`, `X-Forwarded-Access-Token`, `Cookie: _oauth2_proxy=…` and identity headers into the kubeapps-apis pod log, at Info level, on every visit of the *Package Repositories* page. Both klog calls are unconditional: no verbosity level, chart value or flag turns them off, so anyone who can read the pod logs can replay the session for the token lifetime.

This PR logs `request.Msg` instead, which is what the other handlers in the same files already do (e.g. `GetPackageRepositorySummaries` in the helm plugin). No behaviour change beyond the log line.

Observed on v3.0.0 (release chart `kubeapps-3.0.0.tgz`, `authProxy.enabled=true`, `provider=oidc`); the lines are unchanged on `main`. The pattern is inherited from upstream, so 2.x installations are affected the same way.

## Notes for the reviewer

- `request.Msg` is already dereferenced unguarded right after the log in several of these handlers (`GetPackageRepositoryPermissions`, `GetPackageRepositorySummaries`, `GetInstalledPackageSummaries`), and connect-go never hands a nil request to a handler, so the `if request == nil` checks that follow some of the logs are unaffected in practice.
- Mechanical change, one `sed` over the three files; no test asserts on these log lines.
